### PR TITLE
Fix font variable typo

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,7 +16,7 @@
     --font-sans: 'Fixel', system-ui, sans-serif;
     --font-grotesque: 'Fixel', 'FixelSemi', system-ui, sans-serif;
     --font-alt: "ss01";
-    --font-mono: ui-monospace,, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+    --font-mono: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
     --pt-double-canon: 4.666em;
     --pt-canon: 3.999em;
     --pt-double-great-primer: 2.999em;


### PR DESCRIPTION
## Summary
- fix duplicated comma in `--font-mono` definition

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862a2962d8c832faf36f0a98cb33b67